### PR TITLE
defining the proper variable for PayerNameNVP in DoNonReferencedCredit

### DIFF
--- a/src/angelleye/PayPal/PayPal.php
+++ b/src/angelleye/PayPal/PayPal.php
@@ -1902,7 +1902,7 @@ class PayPal
 	{
 		$DNRCFieldsNVP = '&METHOD=DoNonReferencedCredit';
 		$CCDetailsNVP = '';
-		$PayerName = '';
+		$PayerNameNVP = '';
 		$PayerInfoNVP = '';
 		$BillingAddressNVP = '';
 		


### PR DESCRIPTION
In `PayPal::DoNonReferencedCredit()`, the `$PayerName`  variable is wrongly defined - `$PayerNameNVP` must be defined instead, as it is used in the method. 

Using the current version of the code throws a notice for usage of undefined `$PayerNameNVP`. Replacing the `$PayerName = ''` definition with `$PayerNameNVP = ''` fixes this issue.
