### PR TITLE
CURL uses TLSv1.2

### DIFF
--- a/src/angelleye/PayPal/PayPal.php
+++ b/src/angelleye/PayPal/PayPal.php
@@ -617,6 +617,7 @@ class PayPal
 				curl_setopt($curl, CURLOPT_URL, $this->EndPointURL);
 				curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
 				curl_setopt($curl, CURLOPT_POSTFIELDS, $Request);
+				curl_setopt($curl, CURLOPT_SSLVERSION, 6);
 				
 		if($this->APIMode == 'Certificate')
 		{


### PR DESCRIPTION
CURL now uses TLSv1.2 to accommodate the change PayPal is making per https://www.paypal-knowledge.com/infocenter/index?page=content&id=FAQ1913&expand=true&locale=en_US.
