### PR TITLE
Cleanup: rework .gitignore and add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,62 @@
+# --- Line-ending normalization ---
+# Treat all text files as LF in the repo and on Linux/macOS checkouts.
+# Git autodetects text vs binary; this just fixes the EOL when it's text.
+* text=auto eol=lf
+
+# Windows-only scripts must stay CRLF.
+*.bat   text eol=crlf
+*.cmd   text eol=crlf
+*.ps1   text eol=crlf
+
+# Common binary types — never normalize.
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.pdf   binary
+*.zip   binary
+*.gz    binary
+*.tar   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.eot   binary
+
+# --- export-ignore ---
+# Files / directories below are excluded from the Composer / Packagist
+# release tarball (`git archive`). Cloners still see them; merchants who
+# install via `composer require` do not.
+
+# Repo metadata + dotfiles that have no value to package consumers
+.gitattributes   export-ignore
+.gitignore       export-ignore
+.editorconfig    export-ignore
+
+# Local dev environments
+.ddev/**         export-ignore
+.htaccess        export-ignore
+
+# AI agent tooling (local-only metadata)
+.agents/**       export-ignore
+.claude/**       export-ignore
+.codex/**        export-ignore
+
+# CI / contribution / community files
+.github/**       export-ignore
+.travis.yml      export-ignore
+.scrutinizer.yml export-ignore
+CONTRIBUTING.md  export-ignore
+
+# Internal planning / PRD / design docs
+docs/**          export-ignore
+
+# Test infrastructure (when added in v4.0)
+tests/**         export-ignore
+phpunit.xml      export-ignore
+phpunit.xml.dist export-ignore
+phpcs.xml        export-ignore
+phpcs.xml.dist   export-ignore
+
+# NOTE: samples/, templates/, demo/, and documentation/ are intentionally
+# NOT export-ignored — they are user-facing and ship with the package.

--- a/.gitignore
+++ b/.gitignore
@@ -1,59 +1,66 @@
-# General Ignored Files
+# --- OS-generated files ---
 .DS_Store
 Thumbs.db
-
-# OS-generated files
 *.swp
 *.swo
 *.bak
+*.orig
 
-# AI Agents
+# --- Editors / IDEs ---
+.idea/
+*.iml
+.vscode/
+/nbproject/private/
+# PhpStorm/IDEA project XML lives in .idea/ above.
+# Avoid blanket *.xml; ignore specific config files individually below.
+
+# --- Local dev environments ---
+/.ddev/
+/.htaccess
+
+# --- AI agent tooling (local-only metadata) ---
 /.agents/
 /.claude/
 /.codex/
 
-# PHPStorm and IDE-related files
-.idea/
-*.iml
-*.xml
-.vscode/
-phpcs.xml
-
-# Composer dependencies and related files
+# --- Composer / PHP dependencies ---
 /vendor/
 /composer.lock
 
-# Node.js (if npm/yarn is used for assets)
-node_modules/
+# --- PHP tooling caches and configs ---
+/.phpunit.result.cache
+/.phpunit.cache/
+/.php-cs-fixer.cache
+/.phpstan-cache/
+/.psalm/
+/phpcs.xml
+/phpcs.xml.dist
+/phpunit.xml
+/phpunit.xml.dist
 
-# Temporary files
+# --- Build / coverage artifacts ---
+/build/
+/coverage/
+
+# --- Node (if used for asset pipelines) ---
+/node_modules/
+
+# --- Logs and scratch directories ---
 *.log
 *.cache
 *.tmp
 /tmp/
 /temp/
 /logs/
-!logs/.gitkeep  # Exclude logs/.gitkeep, keep the directory structure
+# Keep the logs/ directory in the tree as a placeholder.
+!/logs/.gitkeep
 
-# Private/sensitive files
+# --- Secrets / per-environment config ---
+.env
+.env.*
+# (Files like .env.testing, .env.production, .env.local are all covered above.)
 /includes/config.php
 /admin/config.php
 
-# Git merge conflict files
-*.orig
-
-# PHPUnit
-.phpunit.result.cache
-
-# Coverage and build
-/coverage/
-/build/
-
-# PHP-specific files
-.env
-.env.*       # Include files like .env.testing, .env.production
-/phpunit.xml
-/phpunit.xml.dist
-
-# Ignoring nbproject if NetBeans IDE is used
-/nbproject/private/
+# --- Internal planning / docs not meant for the public package ---
+/docs/


### PR DESCRIPTION
## Summary

Two-file housekeeping change to make the repo follow common OSS PHP library standards and to keep the published Composer / Packagist tarball lean.

### `.gitignore` changes
- **Removes inline comments** that were silently breaking the `!logs/.gitkeep` and `.env.*` patterns. Gitignore treats `pattern # comment` as part of the pattern, not a comment.
- **Replaces the overbroad `*.xml` wildcard** (which would ignore *any* XML file in the repo) with specific PHP-tooling patterns (`/phpunit.xml`, `/phpunit.xml.dist`, `/phpcs.xml`, `/phpcs.xml.dist`).
- **Adds `/.ddev/` and `/.htaccess`** so they no longer rely on local-only `.git/info/exclude` entries (which are per-machine and not visible to other contributors).
- **Adds modern PHP tooling caches** that newer versions of PHPUnit / PHP-CS-Fixer / PHPStan / Psalm produce.
- **Adds `/docs/`** for internal planning content that shouldn't be committed alongside library code.
- Reorganized into clearer sections.

### `.gitattributes` (new)
- **Line-ending normalization** (`text=auto eol=lf`; `*.bat` / `*.cmd` / `*.ps1` forced to CRLF; common binary types marked as such) for cross-platform contributor consistency.
- **`export-ignore` directives** so dev-only files (`.gitattributes`, `.gitignore`, `.ddev`, `.agents`, `.claude`, `.codex`, `.github`, `.htaccess`, `docs`, `tests`, `phpunit.xml*`, `phpcs.xml*`, `CONTRIBUTING.md`, etc.) are excluded from `git archive` and the Packagist release tarball that merchants pull via `composer require`.
- **Intentionally NOT export-ignored**: `samples/`, `templates/`, `demo/`, `documentation/`, `README.md`, `CHANGELOG.md` — these are user-facing and should ship with the package.

## Why this matters

Without `.gitattributes`, every file in the repo (including `.gitignore`, internal planning docs, AI tooling metadata, future `tests/`, etc.) is bundled into the Composer tarball that merchants install. This bloats their `vendor/` directories with files that have no value to consumers of the library.

The `.gitignore` inline-comment bug is subtle: today's `!logs/.gitkeep` rule only "works" because `logs/.gitkeep` was committed before `logs/` was added to `.gitignore` — once-tracked files override later ignore patterns. New similar patterns added in the future would silently fail.

## Test plan

- [x] `git check-ignore -v` confirms `.ddev/`, `.htaccess`, `vendor/`, `composer.lock`, `logs/*` (but not `logs/.gitkeep`), `temp/`, `.DS_Store`, `.agents/`, `.claude/`, `phpunit.xml`, and `docs/` are ignored.
- [x] `git check-ignore` confirms `README.md`, `src/...`, `samples/...`, `composer.json`, and a hypothetical `some-config.xml` are NOT ignored.
- [x] `git check-attr export-ignore` confirms nested files in `.ddev/`, `.agents/`, `.claude/`, `docs/`, `tests/`, `.github/` resolve to `set`, while files in `samples/`, `demo/`, `documentation/`, `src/`, plus `README.md` / `composer.json`, resolve to `unspecified`.
- [x] `git archive --worktree-attributes` smoke test produces a tarball containing only: `CHANGELOG.md`, `README.md`, `autoload.php`, `composer.json`, `demo/`, `documentation/`, `logs/`, `samples/`, `src/`, `templates/`. Zero dotfiles or dev artifacts.

## Notes

- Targets `219_ai` (where the v4.0 modernization work lives). The `release` branch's `.gitignore` is older and missing the broader coverage that's already on `219_ai`; basing here keeps the existing improvements and just fixes the issues.
- After this lands, the local `.git/info/exclude` entries for `/.ddev/` and `/.htaccess` become redundant and can be cleaned up (a per-machine, non-tracked file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)