### PR TITLE
docs(v4.0): bootstrap roadmap planning — 37 iterations + GitHub artifacts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,11 +13,11 @@ Single source of truth for any AI agent working in this repo. `CLAUDE.md` import
 
 ## Tech stack
 
-- **PHP:** `>=8.0` currently; v4.0 will raise the floor (decision deferred to an early iteration — see PRD)
-- **Composer autoload:** PSR-0 today; PSR-4 migration is in v4.0 scope (TBD)
+- **PHP:** `>=8.0` currently; v4.0 raises the floor to `^8.1` (early Phase 0 iteration)
+- **Composer autoload:** PSR-0 today; v4.0 adopts **dual PSR-0 / PSR-4** — new code under `src/REST/`, `src/Legacy/`, `src/Support/` is PSR-4 at the namespace prefix `angelleye\PayPal\{REST,Legacy,Support}\`; the existing classes (`PayPal`, `PayFlow`, `Adaptive`, `Financing`) stay PSR-0 in their current locations under `src/angelleye/PayPal/` to preserve BC for merchants' `use` statements. Full PSR-4 migration of the legacy classes is deferred to v5.0 (when Classic itself is dropped).
 - **Standard for new code:** PSR-12 (legacy code remains PSR-0-laid-out)
-- **Tests:** none configured yet — v4.0 introduces a testing framework as an early iteration
-- **Lint / static analysis:** none configured yet — same as above
+- **Tests:** none configured yet — v4.0 introduces **PHPUnit** as an early Phase 0 iteration
+- **Lint / static analysis:** none configured yet — tool choice (PHP-CS-Fixer / PHPStan / Psalm) deferred; not blocking for v4.0
 - **Local dev:** DDEV (PHP 8.2, Apache, MariaDB) — see [.ddev/config.yaml](.ddev/config.yaml)
 - **Runtime dep:** `ext-curl` only
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -12,7 +12,7 @@ The PayPal PHP SDK at `/home/angellops/projects/paypal-sdk-php/` is a long-stand
 
 **What we're building.** A modernized v4.0 of the SDK that ships full REST support alongside the existing Classic API, plus an "upgrade path" that lets existing Classic integrations transparently route through REST by flipping a single config flag. New integrations start REST-native; legacy integrations get a non-breaking ramp. The release is also the Wekoodo brand rollout.
 
-**Branch.** Continuing on `219_ai`. The OAuth + Orders v2 prototype in `src/angelleye/PayPal/PayPalREST.php` (~410 lines) is structurally sound and gets refactored into the new architecture rather than thrown away.
+**Branch.** Continuing on `feat/219-ppcp-integration` (formerly `219_ai`). The OAuth + Orders v2 prototype in `src/angelleye/PayPal/PayPalREST.php` (~410 lines) was never released in any stable tag and is not in use outside this feature branch; its patterns (OAuth client_credentials flow, header conventions, Orders v2 request/response shapes) inform the new `REST\Client` architecture, but the file itself is deleted in Phase 0 — v4.0 ships a fresh REST stack with no code carried forward from this prototype.
 
 ---
 
@@ -173,9 +173,6 @@ src/angelleye/PayPal/
 ├── Adaptive.php                                KEEP — Adaptive Payments (legacy), flagged @deprecated
 ├── Financing.php                               KEEP — Financing API (legacy), flagged @deprecated
 │
-├── PayPalREST.php                              CONVERT — thin @deprecated proxy delegating to REST\Client
-│                                               so anyone who pulled 219_ai early stays working
-│
 ├── REST/                                       NEW — PSR-4 autoloaded
 │   ├── Client.php                              Facade with lazy resource properties
 │   ├── Config.php                              Immutable value object: client_id, secret, sandbox,
@@ -309,6 +306,12 @@ src/angelleye/PayPal/EventTypesClass.php        Orphaned
 src/angelleye/PayPal/InvoicingClass.php         Orphaned
 src/angelleye/PayPal/PayPalSyncClass.php        Orphaned
 src/angelleye/PayPal/ReferencedPayoutsClass.php Orphaned
+src/angelleye/PayPal/PayPalREST.php             Prototype OAuth + Orders v2 scaffolding from the
+                                                219 feature branch; never released in any stable
+                                                tag and not in use outside this branch. Its patterns
+                                                are read as reference material while building the
+                                                new REST stack, but the file itself does not survive
+                                                into v4.0.
 vendor/paypal/rest-api-sdk-php/                 Abandoned vendor SDK; regenerate composer.lock
 
 # Templates / Samples / Demos — REST counterparts (parallel sibling layout)
@@ -387,14 +390,9 @@ bin/paypal-upgrade-check                        NEW — CLI scanner for merchant
 - Bump `composer.json` PHP floor to `^8.1`. Add PSR-4 autoload entries for new namespaces. Add `psr/log`, `psr/simple-cache` to `require`. Add `guzzlehttp/guzzle` to `suggest`.
 - Extract `PayPal.php:119-489` (Countries/States/AVS/CVV2/Currencies arrays) to `Support\Reference`. Update PayPal.php to load via the new class without changing public method behavior.
 - Set up `phpunit.xml`, `tests/` directory structure, fixtures directory.
-- Convert existing `PayPalREST.php` to a thin `@deprecated` proxy over (yet-to-be-built) `REST\Client`.
+- Delete `src/angelleye/PayPal/PayPalREST.php`. Its OAuth client_credentials flow + Orders v2 patterns are read as reference material when building the new `REST\Auth\OAuth2Authenticator`, `REST\Http\CurlTransport`, and `REST\Resources\Orders` in Phase 1, but the file itself does not survive into v4.0. (The class was never released in a stable tag and is not in use outside the v4.0 feature branch, so there is no BC obligation to keep a deprecated shim.)
 
-**Phase 0b — Brand transition (Week 1, parallel with cleanup).**
-- Update repo metadata: `composer.json` `homepage` and `support.source` to `https://github.com/Wekoodo/paypal-php-library`. Author block can list both Angell EYE (historical) and Wekoodo (current). The package `name` field changes to `wekoodo/paypal-php-library` at the moment of v4.0.0 publish, not before.
-- Update `README.md` header with prominent "**Formerly published as Angell EYE — now Wekoodo.**" notice. Include a "Brand history" section explaining: Angell EYE → angellops (GitHub-only rename) → Wekoodo (v4.0+). Note that the PHP namespace `angelleye\PayPal` is preserved for backward compatibility — no `use` statement changes needed when upgrading from v3.x.
-- Replace any in-code references to "Angell EYE" with "Wekoodo" in user-facing strings (log prefixes, error messages, default `LogPath` directory name if present), keeping the literal namespace `angelleye` intact in PHP code.
-- Update `CHANGELOG.md` with a v4.0.0 entry that opens with the brand change.
-- Coordinate the actual GitHub org migration (`angellops` → `Wekoodo`) with the maintainer; this is a one-click GitHub admin action but should be timed with the v4.0.0 release tag so docs and the new Packagist entry land at the same moment.
+> **Note on brand transition timing.** Earlier drafts of this PRD ran a "Phase 0b" of brand work in parallel with cleanup. That has been consolidated into Phase 6 (Brand & Release) below. The only brand-related work that lands in Phase 0 is the `Support\PartnerAttribution::VALUE = 'WekoodoLLC_Ecom'` constant — because every REST request and the JS SDK helper need that value from day 1 of Phase 1. Everything else visible to the public (composer `name` change, README "Formerly Angell EYE" notice, CHANGELOG brand entry, GitHub org migration, Packagist abandoned flag) clusters at release time so the in-repo brand state stays consistent with what's actually published.
 
 **Phase 1 — Core REST Plumbing (Weeks 2-3).**
 - Build `REST\Config`, `REST\Http\{Request,Response,RequestOptions,Prefer,TransportInterface,CurlTransport}`, `REST\Auth\{OAuth2Authenticator,AccessToken,AuthAssertionBuilder}`, `REST\TokenStore\{TokenStoreInterface,InMemoryTokenStore,FilesystemTokenStore,Psr16TokenStore}`, `REST\Exceptions\*`, `REST\Responses\BaseResponse`, `REST\Resources\BaseResource`, `REST\Client` (facade, lazy resources).
@@ -440,19 +438,30 @@ bin/paypal-upgrade-check                        NEW — CLI scanner for merchant
 - `documentation/brand-history.md` — the Angell EYE → angellops → Wekoodo journey, why the PHP namespace is preserved (`angelleye\PayPal` stays intact), where to find the package on Packagist now (`wekoodo/paypal-php-library` canonical, `angelleye/paypal-php-library` marked abandoned), GitHub redirects, and current contact channels under the Wekoodo brand. Linked prominently from `README.md` and `CHANGELOG.md`.
 - Update `README.md` (with "**Formerly Angell EYE — now Wekoodo**" notice and brand-history link near the top), `CHANGELOG.md` (v4.0.0 entry leads with the brand change, then the REST modernization, then the telemetry removal), and any inline doc-block author/copyright lines in `src/` that mention the old brand.
 
-**Phase 6 — End-to-End Verification & Release (Weeks 15-16).**
+**Phase 6 — Brand & Release (Weeks 15-16).**
+
+*End-to-end verification (the formal release gate).* The bundled demo kits are the gate, not external beta merchants. If all of these run clean in sandbox, v4.0 is releasable:
 - Run `demo/classic/express-checkout-basic/` end-to-end against both backends (`upgrade_from_classic = false` and `true`), diff outputs, verify behavioral parity.
 - Run `demo/rest/checkout-standard/` and `demo/rest/checkout-redirect/` end-to-end in sandbox.
-- Run `bin/paypal-upgrade-check` against three real merchant codebases (e.g., one PayPal + WooCommerce extension, one custom checkout flow, one subscription billing app) and verify the report classifies methods correctly.
+- Run `bin/paypal-upgrade-check` against representative merchant codebases (e.g., one PayPal + WooCommerce extension, one custom checkout flow, one subscription billing app) and verify the report classifies methods correctly.
 - Run full PHPUnit suite — assert ≥ 80% line coverage on `REST/`, `Legacy/`, `Support/` namespaces.
-- Tag `v4.0.0-rc1`, publish to Packagist as a release candidate.
-- After a 2-week RC bake period with community feedback, tag `v4.0.0`.
+
+*In-repo brand transition (lands in this phase, not earlier).* Keeps the in-repo brand state consistent with what's actually published:
+- Update `composer.json`: change `name` from `angelleye/paypal-php-library` to `wekoodo/paypal-php-library`; update `homepage` and `support.source` to `https://github.com/Wekoodo/paypal-php-library`; extend the `authors` block to list both Angell EYE (historical) and Wekoodo (current).
+- Update `README.md` header with prominent "**Formerly published as Angell EYE — now Wekoodo.**" notice and link to a new "Brand history" section explaining: Angell EYE → angellops (GitHub-only rename) → Wekoodo (v4.0+). Note that the PHP namespace `angelleye\PayPal` is preserved for backward compatibility — no `use` statement changes needed when upgrading from v3.x.
+- Replace any in-code references to "Angell EYE" with "Wekoodo" in user-facing strings (log prefixes, error messages, default `LogPath` directory name if present), keeping the literal namespace `angelleye` intact in PHP code.
+- Update `CHANGELOG.md` with a v4.0.0 entry that opens with the brand change, then the REST modernization, then the telemetry removal.
+
+*Release tags.*
+- Tag `v4.0.0-rc1` and publish to Packagist as a release candidate. (Composer's default install behavior is stable-only, so users on `^3.0` won't auto-upgrade — they must explicitly opt in to the RC, e.g., `"wekoodo/paypal-php-library": "^4.0@RC"`.)
+- 1-week RC bake period using the bundled demo kits as the validation gate. If a demo kit fails or surfaces a regression in sandbox during the bake, fix and re-tag (`rc2`, `rc3`, ...). If the demos run clean across the bake window, tag `v4.0.0` for general availability.
+- Coordinate the maintainer-side out-of-band actions to land alongside the `v4.0.0` tag (GitHub org transfer `angellops` → `Wekoodo`, Packagist publish of `wekoodo/paypal-php-library`, marking `angelleye/paypal-php-library` as abandoned — see "Out-of-Band Items" below).
 
 ### Technical Risks
 
 - **EC-token bridge fragility.** The synthetic `EC-XXX` token mapping to REST order_ids depends on a `TokenStore` and on intercepting/rewriting the merchant's `returnurl` so PayPal sends back the synthetic token rather than the raw order_id. If a merchant's framework strips query params, modifies `returnurl` post-call, or runs PayPal redirects in a context where session storage is unavailable (CLI, queued worker), the bridge breaks. **Mitigation:** the bridge accepts BOTH forms on lookup (synthetic token OR raw REST order_id), so even if the rewrite fails, `GetExpressCheckoutDetails` still resolves. Document this fallback explicitly. Add an `EcTokenBridge` integration test that simulates each session storage backend.
 - **Mapper drift.** PayPal's REST and Classic responses are similar but not identical. Subtle field-shape mismatches (currency formatting, address line collapsing, line-item rounding) will surface in production for some merchants. **Mitigation:** comprehensive round-trip tests per mapper with captured real-world fixtures; explicit `behavioral_differences` notes in `documentation/upgrade-from-classic.md`; the upgrade-check CLI flags caveats inline.
-- **Sandbox != live behavior.** PayPal sandbox occasionally diverges from production (test card behavior, Pay Later eligibility, Disputes lifecycle timings). Integration tests passing in sandbox don't guarantee production behavior. **Mitigation:** RC period (2 weeks) with select beta merchants running on production. Documented in `documentation/sandbox-vs-live.md`.
+- **Sandbox != live behavior.** PayPal sandbox occasionally diverges from production (test card behavior, Pay Later eligibility, Disputes lifecycle timings). Integration tests passing in sandbox don't guarantee production behavior. **Mitigation:** the 1-week RC bake (see Phase 6), plus (optionally) beta merchants running the RC against production code. Sandbox-vs-live divergence is an inherent residual risk that the bundled demos can't fully eliminate by definition — `documentation/sandbox-vs-live.md` flags this explicitly so users on `^4.0.0` understand the early-adopter posture.
 - **Token store concurrency.** `FilesystemTokenStore` with file-locking has worked for years in similar libraries, but high-concurrency scenarios (50+ concurrent FPM workers all hitting an expired token) can trigger a thundering herd. **Mitigation:** jittered single-flight refresh inside `OAuth2Authenticator` (refresh delay = `random_int(0, 500)` ms), with file lock as the serialization point.
 - **PHP 8.1 floor excludes some merchants.** Merchants on shared hosting may still be on 8.0 or even 7.4. **Mitigation:** publish a clear deprecation notice in v3.x README and `CHANGELOG.md`; keep v3.x in `support` mode for 12 months post-v4.0 release. v3.x receives security fixes only.
 - **JS SDK helper false-promises.** Merchants who expect `ButtonHelper::renderSmartButtons` to "just work" without writing any JavaScript will be disappointed — they still need to wire `createOrder` / `onApprove` callbacks. **Mitigation:** `ButtonHelper` documentation explicitly states what it does and doesn't do; `demo/rest/checkout-standard/` provides a copy-pasteable working example.
@@ -524,7 +533,9 @@ For each Phase 6 release-gate run:
 - [ ] `README.md` displays the "Formerly Angell EYE — now Wekoodo" notice prominently.
 - [ ] GitHub repo lives at `github.com/Wekoodo/paypal-php-library`; the angellops URL redirects correctly.
 - [ ] Packagist `wekoodo/paypal-php-library` package is published; `angelleye/paypal-php-library` is marked `abandoned` pointing to the new name.
-- [ ] At least 2 beta merchants have run upgrade-mode in production for 2 weeks without regressions on their actual production code paths (not just demos).
+- [ ] All bundled demo kits run clean end-to-end in sandbox — `demo/classic/express-checkout-basic/` in both Classic and `upgrade_from_classic = true` modes (with diffed-identical response shapes), `demo/rest/checkout-standard/`, and `demo/rest/checkout-redirect/`. **This is the formal release gate.**
+- [ ] 1-week RC bake period has elapsed since the `v4.0.0-rc1` tag with no demo-kit regressions.
+- [ ] (Optional) At least 1 beta merchant has run upgrade-mode in production during the RC bake without regressions on actual production code paths.
 
 ---
 
@@ -549,9 +560,6 @@ For each Phase 6 release-gate run:
 - `src/angelleye/PayPal/ReferencedPayoutsClass.php`
 - `vendor/paypal/rest-api-sdk-php/` (whole directory)
 
-**Files that will be converted (kept as a deprecated shim):**
-- `src/angelleye/PayPal/PayPalREST.php` — thin `@deprecated` proxy delegating to `REST\Client` so users who pulled `219_ai` early stay working through one minor version
-
 **New files to create:** see "Proposed File Structure" in §3 above (~120 new files, including resource handlers, response DTOs, exception classes, mappers, helpers, supporting utilities, templates, samples, demo kits, tests, fixtures, documentation).
 
 ---
@@ -563,6 +571,6 @@ These are not code changes but are blockers for the release:
 1. **AWS endpoint and key are already decommissioned** (per maintainer confirmation). No rotation work needed. The code-side cleanup (Phase 0) is the only remaining task. If telemetry is desired in the future, design it as an opt-in `TelemetryInterface` in v4.1+ with documented data fields and clear consent UX.
 2. **Migrate the GitHub repository** from `github.com/angellops/paypal-php-library` to `github.com/Wekoodo/paypal-php-library`. GitHub's transfer-repository flow handles this in one click and sets up automatic redirects from the old URL. Time the transfer with the v4.0.0 release tag so docs and the new Packagist entry land at the same moment.
 3. **Publish the renamed Packagist package.** Create `wekoodo/paypal-php-library` on Packagist pointing at the new GitHub repo URL. Set up Packagist's GitHub webhook so future tags auto-publish. After the v4.0.0 publish succeeds, edit the existing `angelleye/paypal-php-library` package on Packagist and set `"abandoned": "wekoodo/paypal-php-library"` in `composer.json` of the `release` branch (or via the Packagist UI). This makes Composer print the standard "package abandoned, use X instead" notice on every existing merchant's next `composer update`.
-4. **Recruit 2 beta merchants** for the 2-week RC bake period. Ideal mix: one running Express Checkout for e-commerce (will exercise `SetExpressCheckout` / `DoExpressCheckoutPayment` / `RefundTransaction` mappers heavily), one running Recurring Payments (will exercise the Subscriptions mappers including the multi-call Plans + Subscription orchestration). Verify both merchants test on their actual production integration files, not just bundled demos.
+4. **(Optional but recommended) Recruit 1–2 beta merchants** to run v4.0 RC against their production code during the 1-week RC bake. Ideal mix: one running Express Checkout for e-commerce (would exercise `SetExpressCheckout` / `DoExpressCheckoutPayment` / `RefundTransaction` mappers), one running Recurring Payments (would exercise the Subscriptions mappers and the Plans + Subscription orchestration). This is supplemental confidence — the **formal release gate is the bundled demo kits running clean in sandbox** (see Phase 6). Beta merchant testing accelerates discovery of edge cases the demos don't cover, but it is not a blocker for tagging GA.
 5. **Publish a v3.x deprecation notice** on the existing Packagist page and the GitHub README pointing to the v4.0 RC. Set v3.x branch to security-only fixes for 12 months. Make clear that v3.x merchants do NOT need to change `use` statements when upgrading — the namespace `angelleye\PayPal` is preserved.
 6. **Update social and brand assets** — Twitter/X bio, project website (if any), and any related angellops org repos to redirect users to Wekoodo. Coordinate with marketing or do solo, but ensure the brand transition is not just a code-level event.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -182,6 +182,7 @@ There are **three** distinct levels of planning. Don't conflate them — they ha
 - **Scope:** "Exactly what does this iteration ship, in what order, with what tests?"
 - **Cadence:** in batches of 1–3 iterations ahead of execution
 - **Why just-in-time?** Iterations planned 6 months ahead will be wrong by then. Phase-level outlines age slowly; iteration-level specs age fast. Keep specs fresh by writing them close to execution.
+- **Tooling to install at this stage:** the third-party [`to-issues`](https://www.skills.sh/mattpocock/skills/to-issues) skill (Matt Pocock) is a good fit for decomposing one iteration into its 1–3 GitHub issues using vertical-slice / tracer-bullet methodology. Deliberately **not** installed during roadmap planning (issues at that stage are stubs only — the skill would be overkill). Install it before starting the first iteration-spec session and use it alongside `superpowers:writing-plans` from then on.
 
 ### Why split levels 2 and 3 into separate sessions?
 

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -4,6 +4,11 @@ Source of truth for phases and iterations. GitHub milestone (`v4.0`) and issues 
 
 > See [docs/plans/README.md](README.md) for the workflow these phases and iterations plug into.
 
+- **Base branch for iteration work:** `feat/219-ppcp-integration` (NOT `release`)
+- **Vision & scope:** [docs/PRD.md](../PRD.md)
+- **GitHub milestone:** [v4.0](https://github.com/angellops/paypal-php-library/milestones)
+- **Recommended starting iteration:** **0.1 — orphan-vendor-cleanup** (zero dependencies, lowest-risk deletions, smallest iteration in the roadmap — a good calibration session before the rest).
+
 ---
 
 ## Status legend
@@ -19,7 +24,13 @@ Source of truth for phases and iterations. GitHub milestone (`v4.0`) and issues 
 
 | # | Name | Goal | Milestone | Status |
 |---|---|---|---|---|
-| _TBD_ | _Populated in the first roadmap planning session, derived from [docs/PRD.md](../PRD.md)_ | | `v4.0` | 🔵 |
+| 0 | Cleanup & Foundation | Strip the old REST stack + AWS tracker; raise PHP floor to `^8.1`; lay PSR-4 autoload + PHPUnit; introduce `Support\PartnerAttribution` constant + `Support\Reference` extraction. | `v4.0` | 🔵 |
+| 1 | Core REST Plumbing | Value objects, transport, auth, TokenStore drivers, `REST\Client` facade — no PayPal-resource-specific code yet. | `v4.0` | 🔵 |
+| 2 | REST Resource Handlers | 13 handlers + DTOs + unit + sandbox happy-path tests + per-resource doc pages (`documentation/rest/{resource}.md`). | `v4.0` | 🔵 |
+| 3 | Legacy Adapter & Upgrade Path | `Legacy\RESTBackend` + EC-token bridge + 28 mappers + dispatch-hook wiring in `PayPal.php` + `paypal-upgrade-check` CLI. | `v4.0` | 🔵 |
+| 4 | Templates / Samples / Demos / Helper | REST templates + samples paralleling Classic structure; `demo/rest/checkout-standard` + `demo/rest/checkout-redirect`; `Support\ButtonHelper`; config-sample updates. | `v4.0` | 🔵 |
+| 5 | Documentation | Cross-cutting docs only (per-resource docs ship with Phase 2): upgrade-from-classic walkthrough, REST overview, JS SDK guide, webhooks operational guide, migration-from-v3, brand history. | `v4.0` | 🔵 |
+| 6 | Brand & Release | E2E demo verification (release gate); in-repo brand transition (composer rename, README, CHANGELOG, in-code string replacements); RC tag → 1-week bake → GA tag → out-of-band coordination. | `v4.0` | 🔵 |
 
 ---
 
@@ -27,14 +38,104 @@ Source of truth for phases and iterations. GitHub milestone (`v4.0`) and issues 
 
 > One row per iteration. PR closes 1–3 issues. Iteration MD is the executable spec.
 
-### Phase 1: _TBD_
+### Phase 0: Cleanup & Foundation
 
 | # | Slug | Goal (1 line) | Issue(s) | Branch | PR | Status |
 |---|---|---|---|---|---|---|
-| 1.1 | _tbd_ | _tbd_ | — | — | — | 🔵 |
+| 0.1 | orphan-vendor-cleanup | Delete the 7 orphaned legacy REST classes + `PayPalREST.php` + `vendor/paypal/rest-api-sdk-php/`; regenerate `composer.lock`. | #239 | — | — | 🔵 |
+| 0.2 | remove-aws-telemetry | Strip the AWS endpoint URL, `TPV_Parse_Request` / `TPV_Send_Request`, and their call sites from `PayPal.php`. | #240 | — | — | 🔵 |
+| 0.3 | composer-modernization | PHP floor `^8.1`; declare PSR-4 alongside PSR-0 for `angelleye\PayPal\{REST,Legacy,Support}\`; add `psr/log` + `psr/simple-cache`; suggest `guzzlehttp/guzzle`. | #241 | — | — | 🔵 |
+| 0.4 | phpunit-scaffolding | `phpunit.xml`, `tests/Unit` + `tests/Integration` + `tests/Fixtures` tree; first smoke test verifying `PayPal.php` still loads cleanly. | #242 | — | — | 🔵 |
+| 0.5 | partner-attribution-bn-code | New `Support\PartnerAttribution::VALUE = 'WekoodoLLC_Ecom'` constant; replace `AngellEYELLC_Ecom_PHPCatalog` literals in `PayPal.php`. | #243 | — | — | 🔵 |
+| 0.6 | reference-extraction | Extract `PayPal.php:119–489` (Countries / States / AVS / CVV2 / Currencies) to `Support\Reference`; preserve existing public behavior. | #244 | — | — | 🔵 |
+
+### Phase 1: Core REST Plumbing
+
+| # | Slug | Goal (1 line) | Issue(s) | Branch | PR | Status |
+|---|---|---|---|---|---|---|
+| 1.1 | rest-foundation | `REST\Config` + the 12 `REST\Exceptions\*` classes + `REST\Http\{Request, Response, RequestOptions, Prefer, TransportInterface}` + `REST\Auth\{AccessToken, AuthAssertionBuilder}` + `REST\TokenStore\TokenStoreInterface`. All immutable / interface-only. | #245 | — | — | 🔵 |
+| 1.2 | curl-transport | Zero-dep cURL implementation: SSL verification on by default, error → exception mapping, `debug_id` surfacing, headers (Bearer + `PayPal-Request-Id` + `Partner-Attribution-Id`). | #246 | — | — | 🔵 |
+| 1.3 | tokenstore-drivers | `InMemoryTokenStore` (default), `FilesystemTokenStore` (0600 perms + world-readable refusal + file locking), `Psr16TokenStore`; concurrency test simulating 10 forked workers asserting single-flight refresh. | #247 | — | — | 🔵 |
+| 1.4 | oauth2-client-facade | `REST\Auth\OAuth2Authenticator` (client_credentials, single-flight refresh, jittered backoff) + `REST\Resources\BaseResource` + `REST\Responses\BaseResponse` + `REST\Client` (lazy accessors for 13 Phase 2 resources). | #248 | — | — | 🔵 |
+
+### Phase 2: REST Resource Handlers
+
+| # | Slug | Goal (1 line) | Issue(s) | Branch | PR | Status |
+|---|---|---|---|---|---|---|
+| 2.1 | rest-orders | `REST\Resources\Orders` + `OrderResponse` / `CaptureResponse` / `AuthorizationResponse` DTOs; sandbox path: create → capture. Foundational — every other resource's fixtures reference Order/Capture/Authorization. | #249 | — | — | 🔵 |
+| 2.2 | rest-payments | `REST\Resources\Payments` + refund/authorize/capture DTOs; sandbox path: authorize → capture → refund (reuses 2.1 fixtures). | #250 | — | — | 🔵 |
+| 2.3 | rest-webhooks | `REST\Resources\Webhooks` (CRUD on subscriptions + event types) and `REST\Resources\WebhookVerifier` (`/verify-webhook-signature`); doc covers both. | #251 | — | — | 🔵 |
+| 2.4 | rest-plans-catalog | `REST\Resources\Plans` + `REST\Resources\CatalogProducts` — the two subscription prerequisites. | #252 | — | — | 🔵 |
+| 2.5 | rest-subscriptions | `REST\Resources\Subscriptions` (full lifecycle: create / get / update / suspend / activate / cancel / capture); **depends on 2.4's handoff**. | #253 | — | — | 🔵 |
+| 2.6 | rest-invoicing | `REST\Resources\Invoicing` covering invoices + templates + QR code. | #254 | — | — | 🔵 |
+| 2.7 | rest-payouts | `REST\Resources\Payouts` (batch + items + unclaimed). | #255 | — | — | 🔵 |
+| 2.8 | rest-disputes | `REST\Resources\Disputes` (list, get, provide evidence); tested against 2.1/2.2 fixtures. | #256 | — | — | 🔵 |
+| 2.9 | rest-vault | `REST\Resources\Vault` (payment-tokens + setup-tokens v3). | #257 | — | — | 🔵 |
+| 2.10 | rest-identity-reports-referrals | Three smallest handlers in one iteration: `PartnerReferrals` + `Identity` + `Reports`. | #258 | — | — | 🔵 |
+
+### Phase 3: Legacy Adapter & Upgrade Path
+
+| # | Slug | Goal (1 line) | Issue(s) | Branch | PR | Status |
+|---|---|---|---|---|---|---|
+| 3.1 | legacy-adapter-infra | `Legacy\RESTBackend` dispatcher + `EcTokenBridge` + `ResponseShaper` + `ErrorTranslator` + `UnmappableMethods` + `FieldMap` (~200 leaf mappings) + `UnmappableMethodException` / `LegacyConfigException`. No mappers yet. | #259 | — | — | 🔵 |
+| 3.2 | mappers-express-checkout | `SetExpressCheckout`, `GetExpressCheckoutDetails`, `DoExpressCheckoutPayment`, `DoDirectPayment`, `DoReferenceTransaction` mappers (~5) + dispatch hooks; integration tests cover the EC-token bridge end-to-end. | #260 | — | — | 🔵 |
+| 3.3 | mappers-payment-lifecycle | `DoAuthorization`, `DoCapture`, `DoReauthorization`, `DoVoid`, `RefundTransaction`, `ManagePendingTransactionStatus` mappers (~6) + dispatch hooks. | #261 | — | — | 🔵 |
+| 3.4 | mappers-transaction-queries | `GetTransactionDetails`, `TransactionSearch`, `MassPay` (→ Payouts), `GetBalance` (→ Reports) mappers (~4) + dispatch hooks. | #262 | — | — | 🔵 |
+| 3.5 | mappers-recurring-billing | 6 Recurring Profile mappers + 2 Billing Agreement mappers (~8 total) + dispatch hooks. Largest mapper iteration; `CreateRecurringPaymentsProfile` orchestrates Plans + Subscription. | #263 | — | — | 🔵 |
+| 3.6 | mappers-invoicing | `CreateInvoice`, `SendInvoice`, `GetInvoiceDetails`, `UpdateInvoice`, `CancelInvoice` mappers (~5) + dispatch hooks. | #264 | — | — | 🔵 |
+| 3.7 | upgrade-check-cli | `bin/paypal-upgrade-check` using `nikic/php-parser` (dev dep); scans a merchant codebase and classifies Classic method calls as cleanly-upgradable / upgradable-with-caveats / unmappable. | #265 | — | — | 🔵 |
+
+### Phase 4: Templates / Samples / Demos / Helper
+
+| # | Slug | Goal (1 line) | Issue(s) | Branch | PR | Status |
+|---|---|---|---|---|---|---|
+| 4.1 | rest-templates | 32 blank shells under `templates/rest/`, paralleling `templates/classic/`. | #266 | — | — | 🔵 |
+| 4.2 | rest-samples | 32 populated runnable samples under `samples/rest/`, paralleling `samples/classic/`. | #267 | — | — | 🔵 |
+| 4.3 | demo-rest-checkout-standard | Modern Smart Buttons demo (5 files: `index.php` with JS SDK + `create-order.php` XHR + `capture-order.php` XHR + `order-complete.php` + shared `assets/`) plus `Support\ButtonHelper`. | #268 | — | — | 🔵 |
+| 4.4 | demo-rest-checkout-redirect | Server-only redirect demo (6 files mirroring `demo/classic/express-checkout-basic/`) + `samples/config/config-sample.php` updated with all new config keys. | #269 | — | — | 🔵 |
+
+### Phase 5: Documentation
+
+| # | Slug | Goal (1 line) | Issue(s) | Branch | PR | Status |
+|---|---|---|---|---|---|---|
+| 5.1 | docs-upgrade-from-classic | `documentation/upgrade-from-classic.md` — the full 5-step migration: mapping table for the 28 mapped Classic methods, unmappable list, EC-token bridge explanation, `classic_methods_passthrough` usage. | #270 | — | — | 🔵 |
+| 5.2 | docs-rest-overview-jssdk | `documentation/rest/index.md` (architecture overview + getting-started) + `documentation/js-sdk-upgrade-guide.md` (Smart Buttons UX modernization). | #271 | — | — | 🔵 |
+| 5.3 | docs-webhooks-migration-history | `documentation/webhooks.md` (operational guide) + `documentation/migration-from-v3.md` + `documentation/brand-history.md` (Angell EYE → angellops → Wekoodo). | #272 | — | — | 🔵 |
+
+### Phase 6: Brand & Release
+
+| # | Slug | Goal (1 line) | Issue(s) | Branch | PR | Status |
+|---|---|---|---|---|---|---|
+| 6.1 | e2e-verification | Run all demo kits in sandbox (Classic, upgrade mode, REST Smart Buttons, REST redirect); full PHPUnit suite at ≥80% line coverage on `REST/` / `Legacy/` / `Support/`; `paypal-upgrade-check` against representative codebases; fix regressions. | #273 | — | — | 🔵 |
+| 6.2 | brand-transition | `composer.json` rename (`name` → `wekoodo/paypal-php-library`, Wekoodo URLs, authors block) + `README.md` Wekoodo notice + `CHANGELOG.md` v4.0.0 entry + in-code "Angell EYE" → "Wekoodo" replacements in user-facing strings only (namespace `angelleye` preserved). | #274 | — | — | 🔵 |
+| 6.3 | release-ceremony | Tag `v4.0.0-rc1`; 1-week RC bake with demo kits as validation gate; tag `v4.0.0` GA; close v4.0 milestone; coordinate out-of-band actions (GitHub org transfer, Packagist publish, abandoned flag). | #275 | — | — | 🔵 |
+
+---
+
+## Out-of-band items (maintainer actions, not iterations)
+
+Tracked on the v4.0 milestone with the `out-of-band` label. These are not coded iterations — they're maintainer actions that have to land alongside the `v4.0.0` tag. Six items from the PRD's "Out-of-Band Items" section:
+
+| # | Item | Coordinates with | Issue | Status |
+|---|---|---|---|---|
+| OOB-1 | AWS endpoint decommission confirmation (already done per maintainer) | — | #276 | ✅ |
+| OOB-2 | GitHub org transfer `angellops` → `Wekoodo` | iteration 6.3 | #277 | 🔵 |
+| OOB-3 | Packagist publish of `wekoodo/paypal-php-library` (with auto-tag webhook) | iteration 6.3 | #278 | 🔵 |
+| OOB-4 | Mark `angelleye/paypal-php-library` as `"abandoned": "wekoodo/paypal-php-library"` on Packagist | iteration 6.3 (after publish) | #279 | 🔵 |
+| OOB-5 | (Optional) Recruit 1–2 beta merchants for the 1-week RC bake | iteration 6.3 (RC bake window) | #280 | 🔵 |
+| OOB-6 | v3.x deprecation notice + social/brand asset updates | iteration 6.3 | #281 | 🔵 |
+
+---
+
+## Maintenance notes
+
+- **After each iteration is merged:** flip the row's Status to ✅, fill in the PR column with the merged PR URL.
+- **When iteration work starts:** flip Status to 🟡, fill in the Branch column.
+- **If an iteration splits during iteration-spec planning** (e.g., 3.5 ends up being two PRs): renumber sub-rows as `3.5a` / `3.5b` and update both this table and the GitHub milestone.
+- **The Issue column was filled in** when the v4.0 milestone's stub issues were created in Stage 4 of the roadmap-planning session (issues #239–#281). It doesn't change after that.
 
 ---
 
 ## Change log
 
-- _Empty — the first roadmap planning session populates this roadmap from the PRD._
+- **2026-05-16** — Initial roadmap population. 37 iterations across 7 phases sized to 1–2 SP each. Decisions baked in: delete `PayPalREST.php` (no carry-forward), brand transition deferred to Phase 6, PHPUnit (not Pest), dual PSR-0/PSR-4 (full migration deferred to v5.0), each Phase 3 mapper iteration wires its own dispatch hooks, 1-week RC bake with demo kits as the validation gate.


### PR DESCRIPTION
## Iteration

Not part of an iteration — this is the **bootstrap PR from the v4.0 roadmap-planning session**. It establishes `docs/plans/ROADMAP.md` as the source of truth for v4.0 phases and iterations, resolves outstanding PRD / AGENTS.md ambiguities ahead of the first iteration, and lands the v4.0 GitHub milestone + label scheme + 43 stub issues.

## Summary

- Resolve 4 outstanding v4.0 design decisions in `docs/PRD.md` and `AGENTS.md` (`PayPalREST.php` fate, brand transition timing, RC bake length, tech-stack TBDs).
- Populate `docs/plans/ROADMAP.md` from stub to full **37-iteration roadmap** with backfilled GitHub issue numbers ([#239–#281](https://github.com/angellops/paypal-php-library/milestone/11)).
- Land the GitHub planning artifacts: **v4.0 milestone** (#11), **10 new labels** (`phase-0` through `phase-6` + `iteration` + `out-of-band` + `release-gate`), **37 iteration stub issues**, **6 out-of-band stub issues**.

## Scope

- **In scope:**
  - `docs/PRD.md` — 10 surgical edits (PayPalREST.php deleted in Phase 0 instead of converted to a deprecated proxy; Phase 0b removed and consolidated into a new Phase 6 "Brand & Release"; 1-week RC bake with demo kits as validation gate; beta merchants made optional).
  - `AGENTS.md` — resolved 3 tech-stack TBDs (PHP `^8.1`, dual PSR-0 / PSR-4 autoload with full migration deferred to v5.0, PHPUnit).
  - `docs/plans/ROADMAP.md` — populated with all 37 iterations + 6 out-of-band items, each row linked to its GitHub issue number.
  - `docs/plans/README.md` — added a note about installing Matt Pocock's `to-issues` skill before the first level-3 iteration-spec session.
  - GitHub: v4.0 milestone, 10 labels, 43 stub issues (OOB-1 closed since AWS-side decommission was already complete).
- **Out of scope (deferred):**
  - Detailed iteration-spec MDs (`docs/plans/iteration-N.M-<slug>.md`) — deliberately deferred to per-iteration sessions per the just-in-time level-3 planning principle.
  - Any actual source-code changes for v4.0 — those start with iteration 0.1 ([#239](https://github.com/angellops/paypal-php-library/issues/239)).
  - Installation of the `to-issues` skill — happens at the first iteration-spec session.

## BC / Compat impact

**None.** Documentation files and GitHub planning artifacts only. No source code, no `composer.json` changes, no public-facing surface affected.

## Test plan

- [x] All 43 stub issues created with correct labels (counts: `iteration`=37, `out-of-band`=6, `phase-0..6` distributed correctly).
- [x] Milestone v4.0 (#11) has 42 open + 1 closed (OOB-1 closed since AWS decommission was already done by the maintainer).
- [x] `ROADMAP.md` issue backfill verified — issues #239–#281 inlined into the correct rows.
- [x] Grep'd PRD for stale references after edits — no `2-week RC`, `Phase 0b`, `deferred to an early iteration`, `CONVERT`, or `thin @deprecated` remain.
- [x] AGENTS.md no longer says any tech-stack item is TBD.

## Handoff notes

**Recommended starting iteration: [Iter 0.1 — orphan-vendor-cleanup](https://github.com/angellops/paypal-php-library/issues/239)** (#239). Zero dependencies, lowest-risk deletions, smallest iteration in the roadmap — a good calibration session before tackling the rest.

When starting the first iteration-spec session (writing `docs/plans/iteration-0.1-orphan-vendor-cleanup.md`), **install the third-party `to-issues` skill first** — see the note in `docs/plans/README.md` §"Iteration-spec planning". The skill provides vertical-slice issue decomposition that becomes useful when breaking an iteration into its component 1–3 GitHub issues.

After this PR merges, the roadmap-planning session is complete. No handoff file is written for this PR because it's a bootstrap, not an iteration.

## Issues

This PR doesn't close any of the 43 stub issues it creates — they're deliberately left open for the iteration-spec / execution sessions that follow. The [v4.0 milestone (#11)](https://github.com/angellops/paypal-php-library/milestone/11) tracks the full set.