### PR TITLE
docs: pivot v4.0 iteration-spec planning from just-in-time to phase-batch

### DIFF
--- a/.agents/skills/to-issues/SKILL.md
+++ b/.agents/skills/to-issues/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: to-issues
+description: Break a plan, spec, or PRD into independently-grabbable issues on the project issue tracker using tracer-bullet vertical slices. Use when user wants to convert a plan into issues, create implementation tickets, or break down work into issues.
+---
+
+# To Issues
+
+Break a plan into independently-grabbable issues using vertical slices (tracer bullets).
+
+The issue tracker and triage label vocabulary should have been provided to you — run `/setup-matt-pocock-skills` if not.
+
+## Process
+
+### 1. Gather context
+
+Work from whatever is already in the conversation context. If the user passes an issue reference (issue number, URL, or path) as an argument, fetch it from the issue tracker and read its full body and comments.
+
+### 2. Explore the codebase (optional)
+
+If you have not already explored the codebase, do so to understand the current state of the code. Issue titles and descriptions should use the project's domain glossary vocabulary, and respect ADRs in the area you're touching.
+
+### 3. Draft vertical slices
+
+Break the plan into **tracer bullet** issues. Each issue is a thin vertical slice that cuts through ALL integration layers end-to-end, NOT a horizontal slice of one layer.
+
+Slices may be 'HITL' or 'AFK'. HITL slices require human interaction, such as an architectural decision or a design review. AFK slices can be implemented and merged without human interaction. Prefer AFK over HITL where possible.
+
+<vertical-slice-rules>
+- Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
+- A completed slice is demoable or verifiable on its own
+- Prefer many thin slices over few thick ones
+</vertical-slice-rules>
+
+### 4. Quiz the user
+
+Present the proposed breakdown as a numbered list. For each slice, show:
+
+- **Title**: short descriptive name
+- **Type**: HITL / AFK
+- **Blocked by**: which other slices (if any) must complete first
+- **User stories covered**: which user stories this addresses (if the source material has them)
+
+Ask the user:
+
+- Does the granularity feel right? (too coarse / too fine)
+- Are the dependency relationships correct?
+- Should any slices be merged or split further?
+- Are the correct slices marked as HITL and AFK?
+
+Iterate until the user approves the breakdown.
+
+### 5. Publish the issues to the issue tracker
+
+For each approved slice, publish a new issue to the issue tracker. Use the issue body template below. These issues are considered ready for AFK agents, so publish them with the correct triage label unless instructed otherwise.
+
+Publish issues in dependency order (blockers first) so you can reference real issue identifiers in the "Blocked by" field.
+
+<issue-template>
+## Parent
+
+A reference to the parent issue on the issue tracker (if the source was an existing issue, otherwise omit this section).
+
+## What to build
+
+A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation.
+
+Avoid specific file paths or code snippets — they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it here and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Blocked by
+
+- A reference to the blocking ticket (if any)
+
+Or "None - can start immediately" if no blockers.
+
+</issue-template>
+
+Do NOT close or modify any parent issue.

--- a/.claude/commands/plan-phase.md
+++ b/.claude/commands/plan-phase.md
@@ -14,8 +14,6 @@ Read, in this order:
 3. Relevant `docs/PRD.md` section(s) for Phase `$ARGUMENTS`
 4. Any prior phases' handoff files under `docs/plans/handoffs/` (only if they exist and are relevant)
 
-Verify the third-party `to-issues` skill (Matt Pocock, [skills.sh](https://www.skills.sh/mattpocock/skills/to-issues)) is available in the discoverable-skills list for this session. It should already be — the repo tracks it under `.agents/skills/to-issues/` per the convention in `.gitignore` and `skills-lock.json`. **If it is NOT available, stop and ask the user to install it.** Do not auto-install third-party skills; that is a local-environment mutation + supply-chain action that requires explicit human approval, not a side effect of running this slash command. This skill is the workhorse for decomposing each spec into vertical-slice GitHub issue bodies.
-
 ## Step 2 — Summarize and check in (do NOT proceed past this step on your own)
 
 Give me a short summary of:
@@ -33,19 +31,17 @@ For each iteration in the phase, in roadmap order:
 
 1. Use `superpowers:writing-plans` to draft the iteration spec
 2. Save the spec to `docs/plans/iteration-N.M-<slug>.md` using the template in `docs/plans/README.md`
-3. Use the `to-issues` skill to derive **1–3** vertical-slice issue bodies from the spec
-4. Populate the GitHub issue tracker:
-   - **If `to-issues` produced exactly 1 body:** update the iteration's existing stub issue (number from the ROADMAP.md row) with `gh issue edit <number> --body-file <path>`.
-   - **If `to-issues` produced 2 or 3 bodies:** treat the existing stub as the *primary* slice — update it with the first body via `gh issue edit`. Then `gh issue create` each additional body, applying the same milestone (`v4.0`) and labels (the iteration's `phase-N` + `iteration`) so they cluster with the rest. Each newly-created issue's body should open with `Sub-issue of #<primary>` so the tracker link back is explicit.
-5. If new issues were created in step 4, update the iteration's ROADMAP.md row to list all issue numbers in the Issue column (e.g., `#239, #284`) and update the iteration spec's `**GitHub issues:**` frontmatter line to match.
+3. Derive a single GitHub issue body from the spec (1–2 paragraph description + acceptance criteria + scope notes — pulled directly from the spec sections of the same names) and update the iteration's existing stub issue (number from the ROADMAP.md row) with `gh issue edit <number> --body-file <path>`
 
 Write specs in roadmap order (0.1 → 0.2 → ...) so each can reference its predecessors' planned handoffs.
+
+**One iteration → one spec → one populated stub issue.** Iterations are sized at the roadmap-planning stage so each fits in one PR; further decomposition into sibling sub-issues isn't a goal of this workflow.
 
 ## Step 4 — Wrap up
 
 - Update `docs/plans/ROADMAP.md` if any iteration scope clarified or split during planning
 - Commit (`git-commit` skill) — Conventional Commit, type `docs`
-- Open PR (`branch-and-pr-conventions` skill) — base branch is `feat/219-ppcp-integration`
+- Open PR. **Base branch:** `feat/219-ppcp-integration`. **Branch-name exception:** because phase-planning PRs close no iteration issues, the standard `{type}/{issue-number}-{slug}` branch convention from [`branch-and-pr-conventions`](../../.agents/skills/branch-and-pr-conventions/SKILL.md) doesn't apply. Use `docs/plan-phase-$ARGUMENTS` (e.g., `docs/plan-phase-0`) and state the exception explicitly in the PR body. All other PR conventions (template sections, BC/Compat impact note, etc.) still apply.
 - PR closes none of the iteration issues by design (those close on execution PRs); reference the v4.0 milestone
 
 Hand back to me with the PR URL and a 1–2 sentence summary of what's now ready for `/execute-iteration N.M` sessions in this phase.

--- a/.claude/commands/plan-phase.md
+++ b/.claude/commands/plan-phase.md
@@ -1,0 +1,48 @@
+---
+description: Plan one phase's iteration specs and flesh out their GitHub issue bodies
+argument-hint: <phase-number, e.g. 0>
+---
+
+You are starting a phase-planning session for Phase `$ARGUMENTS`. This is **level-3** planning — writing detailed iteration specs and populating their GitHub issue bodies for one phase, *before* any iteration in that phase executes.
+
+## Step 1 — Get context
+
+Read, in this order:
+
+1. `docs/plans/README.md` — the workflow this repo uses
+2. `docs/plans/ROADMAP.md` — find the Phase `$ARGUMENTS` rows and note their iteration numbers + issue numbers
+3. Relevant `docs/PRD.md` section(s) for Phase `$ARGUMENTS`
+4. Any prior phases' handoff files under `docs/plans/handoffs/` (only if they exist and are relevant)
+
+Verify the third-party `to-issues` skill (Matt Pocock, [skills.sh](https://www.skills.sh/mattpocock/skills/to-issues)) is installed locally. If it's not, install it before proceeding — this skill is the workhorse for decomposing each spec into vertical-slice GitHub issue bodies.
+
+## Step 2 — Summarize and check in (do NOT proceed past this step on your own)
+
+Give me a short summary of:
+
+- The phase's iterations (titles + 1-line goals from ROADMAP.md)
+- Your planned approach skeleton for each (scope in/out, dependencies, test strategy)
+- Cross-iteration handoffs you anticipate within this phase
+- Any ambiguities, open questions, or blockers
+
+Then **wait for my green light** before writing specs.
+
+## Step 3 — After I green-light
+
+For each iteration in the phase, in roadmap order:
+
+1. Use `superpowers:writing-plans` to draft the iteration spec
+2. Save the spec to `docs/plans/iteration-N.M-<slug>.md` using the template in `docs/plans/README.md`
+3. Use the `to-issues` skill to derive 1–3 vertical-slice issue bodies from the spec
+4. Update the corresponding GitHub issue (number from the ROADMAP.md row) with the new body via `gh issue edit <number> --body-file <path>`
+
+Write specs in roadmap order (0.1 → 0.2 → ...) so each can reference its predecessors' planned handoffs.
+
+## Step 4 — Wrap up
+
+- Update `docs/plans/ROADMAP.md` if any iteration scope clarified or split during planning
+- Commit (`git-commit` skill) — Conventional Commit, type `docs`
+- Open PR (`branch-and-pr-conventions` skill) — base branch is `feat/219-ppcp-integration`
+- PR closes none of the iteration issues by design (those close on execution PRs); reference the v4.0 milestone
+
+Hand back to me with the PR URL and a 1–2 sentence summary of what's now ready for `/execute-iteration N.M` sessions in this phase.

--- a/.claude/commands/plan-phase.md
+++ b/.claude/commands/plan-phase.md
@@ -31,7 +31,7 @@ For each iteration in the phase, in roadmap order:
 
 1. Use `superpowers:writing-plans` to draft the iteration spec
 2. Save the spec to `docs/plans/iteration-N.M-<slug>.md` using the template in `docs/plans/README.md`
-3. Derive a single GitHub issue body from the spec (1–2 paragraph description + acceptance criteria + scope notes — pulled directly from the spec sections of the same names) and update the iteration's existing stub issue (number from the ROADMAP.md row) with `gh issue edit <number> --body-file <path>`
+3. Derive a single GitHub issue body from the spec — copy the spec's **Goal**, **Scope**, and **Acceptance criteria** sections verbatim into the issue body (these are the template section names from `docs/plans/README.md`'s "Iteration spec template"). Then update the iteration's existing stub issue (number from the ROADMAP.md row) with `gh issue edit <number> --body-file <path>`
 
 Write specs in roadmap order (0.1 → 0.2 → ...) so each can reference its predecessors' planned handoffs.
 
@@ -39,7 +39,7 @@ Write specs in roadmap order (0.1 → 0.2 → ...) so each can reference its pre
 
 ## Step 4 — Wrap up
 
-- Update `docs/plans/ROADMAP.md` if any iteration scope clarified or split during planning
+- Update `docs/plans/ROADMAP.md` if any iteration scope clarified or split during planning. **If an iteration was split** (e.g., 3.5 → 3.5a / 3.5b), per `ROADMAP.md`'s own maintenance note you must update **both** the ROADMAP table **and** the GitHub milestone — rename the existing stub issue's title to match the split (e.g., "Iter 3.5a — ..."), add the corresponding labels, and `gh issue create` the additional sub-iteration's stub on the same milestone with the same labels. ROADMAP and GitHub stay in sync.
 - Commit (`git-commit` skill) — Conventional Commit, type `docs`
 - Open PR. **Base branch:** `feat/219-ppcp-integration`. **Branch-name exception:** because phase-planning PRs close no iteration issues, the standard `{type}/{issue-number}-{slug}` branch convention from [`branch-and-pr-conventions`](../../.agents/skills/branch-and-pr-conventions/SKILL.md) doesn't apply. Use `docs/plan-phase-$ARGUMENTS` (e.g., `docs/plan-phase-0`) and state the exception explicitly in the PR body. All other PR conventions (template sections, BC/Compat impact note, etc.) still apply.
 - PR closes none of the iteration issues by design (those close on execution PRs); reference the v4.0 milestone

--- a/.claude/commands/plan-phase.md
+++ b/.claude/commands/plan-phase.md
@@ -14,7 +14,7 @@ Read, in this order:
 3. Relevant `docs/PRD.md` section(s) for Phase `$ARGUMENTS`
 4. Any prior phases' handoff files under `docs/plans/handoffs/` (only if they exist and are relevant)
 
-Verify the third-party `to-issues` skill (Matt Pocock, [skills.sh](https://www.skills.sh/mattpocock/skills/to-issues)) is installed locally. If it's not, install it before proceeding — this skill is the workhorse for decomposing each spec into vertical-slice GitHub issue bodies.
+Verify the third-party `to-issues` skill (Matt Pocock, [skills.sh](https://www.skills.sh/mattpocock/skills/to-issues)) is available in the discoverable-skills list for this session. It should already be — the repo tracks it under `.agents/skills/to-issues/` per the convention in `.gitignore` and `skills-lock.json`. **If it is NOT available, stop and ask the user to install it.** Do not auto-install third-party skills; that is a local-environment mutation + supply-chain action that requires explicit human approval, not a side effect of running this slash command. This skill is the workhorse for decomposing each spec into vertical-slice GitHub issue bodies.
 
 ## Step 2 — Summarize and check in (do NOT proceed past this step on your own)
 
@@ -33,8 +33,11 @@ For each iteration in the phase, in roadmap order:
 
 1. Use `superpowers:writing-plans` to draft the iteration spec
 2. Save the spec to `docs/plans/iteration-N.M-<slug>.md` using the template in `docs/plans/README.md`
-3. Use the `to-issues` skill to derive 1–3 vertical-slice issue bodies from the spec
-4. Update the corresponding GitHub issue (number from the ROADMAP.md row) with the new body via `gh issue edit <number> --body-file <path>`
+3. Use the `to-issues` skill to derive **1–3** vertical-slice issue bodies from the spec
+4. Populate the GitHub issue tracker:
+   - **If `to-issues` produced exactly 1 body:** update the iteration's existing stub issue (number from the ROADMAP.md row) with `gh issue edit <number> --body-file <path>`.
+   - **If `to-issues` produced 2 or 3 bodies:** treat the existing stub as the *primary* slice — update it with the first body via `gh issue edit`. Then `gh issue create` each additional body, applying the same milestone (`v4.0`) and labels (the iteration's `phase-N` + `iteration`) so they cluster with the rest. Each newly-created issue's body should open with `Sub-issue of #<primary>` so the tracker link back is explicit.
+5. If new issues were created in step 4, update the iteration's ROADMAP.md row to list all issue numbers in the Issue column (e.g., `#239, #284`) and update the iteration spec's `**GitHub issues:**` frontmatter line to match.
 
 Write specs in roadmap order (0.1 → 0.2 → ...) so each can reference its predecessors' planned handoffs.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,4 @@ Available under [.agents/skills/](.agents/skills/) (symlinked to `.claude/skills
 - [git-commit](.agents/skills/git-commit/) — Conventional Commit message generation
 - [branch-and-pr-conventions](.agents/skills/branch-and-pr-conventions/) — repo-specific git/PR rules (branch naming, base branch, PR body sections)
 - [stripe-best-practices](.agents/skills/stripe-best-practices/) — Stripe reference (for parity/comparison only)
+- [to-issues](.agents/skills/to-issues/) — ad-hoc decomposition of a plan/spec into vertical-slice GitHub issues (Matt Pocock, from skills.sh). **Not used by `/plan-phase`** — the v4.0 phase-planning workflow ships one issue per iteration (no further decomposition). Available for one-off decomposition work outside the iteration framework.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -178,11 +178,11 @@ There are **three** distinct levels of planning. Don't conflate them — they ha
 ### 3. Phase planning — iteration specs, one phase at a time
 
 - **Input:** all iteration rows for one phase from the roadmap, plus relevant PRD section(s), plus prior phases' handoff files if any
-- **Output:** N iteration spec MDs (`docs/plans/iteration-N.M-<slug>.md`) **and** populated GitHub issue bodies for that phase. Each iteration's existing level-2 stub is rewritten with real content here. Iterations that `to-issues` decomposes into 2–3 vertical slices spawn additional GitHub issues — the existing stub becomes the **primary** slice, and the additional slices are created as new issues on the same milestone with the same phase + `iteration` labels (each linked back via `Sub-issue of #<primary>` in its body). The iteration's ROADMAP.md row is updated to list all issue numbers in its Issue column.
+- **Output:** N iteration spec MDs (`docs/plans/iteration-N.M-<slug>.md`) **and** N populated GitHub issue bodies for that phase. Each iteration's existing level-2 stub is rewritten with real content derived from its spec. **One iteration → one spec → one populated stub issue body** (which the execution PR closes later via `/execute-iteration`). Iterations are sized at level-2 to fit one PR each; further decomposition into sibling sub-issues isn't a goal of this workflow.
 - **Scope:** "Exactly what does each iteration in this phase ship, in what order, with what tests?"
 - **Cadence:** one batch per phase, written *before* that phase's first iteration executes
 - **Slash command:** `/plan-phase N` (see `.claude/commands/plan-phase.md`)
-- **Skills used:** `superpowers:writing-plans` (for the spec content) + the third-party [`to-issues`](https://www.skills.sh/mattpocock/skills/to-issues) skill from Matt Pocock (for decomposing each iteration into 1–3 vertical-slice GitHub issue bodies). Install `to-issues` once, before the first phase-planning session, then use both skills together from then on.
+- **Skills used:** `superpowers:writing-plans` for the spec content. The iteration's stub issue body is derived directly from the spec (description + acceptance criteria + scope notes) and applied via `gh issue edit` — no specialized decomposition skill is required at level 3.
 
 ### Why split levels 2 and 3 into separate sessions?
 

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -40,7 +40,7 @@ PRD                                — vision (docs/PRD.md)
 | [`docs/PRD.md`](../PRD.md) | Vision & scope for v4.0 | Authored once, edited rarely | During **planning** only — never auto-loaded during execution |
 | [`docs/plans/README.md`](README.md) | This file — the workflow itself | Updated when workflow changes | Once per agent, then forgotten |
 | [`docs/plans/ROADMAP.md`](ROADMAP.md) | Phase + iteration index | Updated after every iteration | During planning; **not** read by iteration sessions |
-| `docs/plans/iteration-N.M-<slug>.md` | The spec for one iteration | Written **just before** execution (often in batches of 2–3 ahead) | The session executing iteration N.M |
+| `docs/plans/iteration-N.M-<slug>.md` | The spec for one iteration | Written in **phase-batch** sessions before that phase's first iteration executes | The session executing iteration N.M |
 | `docs/plans/handoffs/iteration-N.M-handoff.md` | Delta produced by completing N.M | Written by the iteration as part of "done" | Only by iterations that explicitly list it as a dependency |
 
 ---
@@ -173,20 +173,20 @@ There are **three** distinct levels of planning. Don't conflate them — they ha
 - **Scope:** "What phases? What iterations under each? In what order?"
 - **Cadence:** once at the start of a major version, then small adjustments as iterations reveal needed splits/merges
 - **Slash command:** `/plan-roadmap` (see `.claude/commands/plan-roadmap.md`)
-- **Stays at title + 1-line goal per iteration.** Does **not** write detailed iteration specs.
+- **Stays at title + 1-line goal per iteration.** Does **not** write detailed iteration specs — those are produced later by per-phase planning sessions (level 3 below), which also flesh out the stub issue bodies.
 
-### 3. Iteration-spec planning — just-in-time
+### 3. Phase planning — iteration specs, one phase at a time
 
-- **Input:** one (or a few) row(s) from the roadmap, plus relevant PRD section(s)
-- **Output:** one (or a few) `docs/plans/iteration-N.M-<slug>.md` file(s)
-- **Scope:** "Exactly what does this iteration ship, in what order, with what tests?"
-- **Cadence:** in batches of 1–3 iterations ahead of execution
-- **Why just-in-time?** Iterations planned 6 months ahead will be wrong by then. Phase-level outlines age slowly; iteration-level specs age fast. Keep specs fresh by writing them close to execution.
-- **Tooling to install at this stage:** the third-party [`to-issues`](https://www.skills.sh/mattpocock/skills/to-issues) skill (Matt Pocock) is a good fit for decomposing one iteration into its 1–3 GitHub issues using vertical-slice / tracer-bullet methodology. Deliberately **not** installed during roadmap planning (issues at that stage are stubs only — the skill would be overkill). Install it before starting the first iteration-spec session and use it alongside `superpowers:writing-plans` from then on.
+- **Input:** all iteration rows for one phase from the roadmap, plus relevant PRD section(s), plus prior phases' handoff files if any
+- **Output:** N iteration spec MDs (`docs/plans/iteration-N.M-<slug>.md`) **and** N populated GitHub issue bodies for that phase (the level-2 stubs are rewritten with real content here)
+- **Scope:** "Exactly what does each iteration in this phase ship, in what order, with what tests?"
+- **Cadence:** one batch per phase, written *before* that phase's first iteration executes
+- **Slash command:** `/plan-phase N` (see `.claude/commands/plan-phase.md`)
+- **Skills used:** `superpowers:writing-plans` (for the spec content) + the third-party [`to-issues`](https://www.skills.sh/mattpocock/skills/to-issues) skill from Matt Pocock (for decomposing each iteration into 1–3 vertical-slice GitHub issue bodies). Install `to-issues` once, before the first phase-planning session, then use both skills together from then on.
 
 ### Why split levels 2 and 3 into separate sessions?
 
-Context economy. A roadmap-planning session needs the full PRD loaded — a heavy context cost paid once. An iteration-spec session needs only the one relevant roadmap row + maybe one PRD section + (sometimes) the prior handoff — much lighter. Mixing them defeats the whole point of the workflow.
+Context economy and scope focus. A roadmap-planning session (level 2) needs the full PRD loaded — a heavy context cost paid once to lay out all phases and iterations. A phase-planning session (level 3) needs only the one phase's roadmap rows + relevant PRD section(s) + prior phases' handoffs — much lighter, and lets each session concentrate on one phase's design end-to-end without mixing in unrelated work. Splitting keeps each session focused on one concern at one altitude.
 
 ---
 
@@ -204,5 +204,6 @@ Context economy. A roadmap-planning session needs the full PRD loaded — a heav
 | Commit message format | [.agents/skills/git-commit/](../../.agents/skills/git-commit/) |
 | PR template | [.github/pull_request_template.md](../../.github/pull_request_template.md) |
 | Iteration issue template | [.github/ISSUE_TEMPLATE/iteration-issue.md](../../.github/ISSUE_TEMPLATE/iteration-issue.md) |
-| Slash command to plan the roadmap | `.claude/commands/plan-roadmap.md` |
+| Slash command to plan the roadmap (level 2) | `.claude/commands/plan-roadmap.md` |
+| Slash command to plan one phase's iteration specs (level 3) | `.claude/commands/plan-phase.md` |
 | Slash command to start an iteration | `.claude/commands/execute-iteration.md` |

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -178,7 +178,7 @@ There are **three** distinct levels of planning. Don't conflate them — they ha
 ### 3. Phase planning — iteration specs, one phase at a time
 
 - **Input:** all iteration rows for one phase from the roadmap, plus relevant PRD section(s), plus prior phases' handoff files if any
-- **Output:** N iteration spec MDs (`docs/plans/iteration-N.M-<slug>.md`) **and** N populated GitHub issue bodies for that phase (the level-2 stubs are rewritten with real content here)
+- **Output:** N iteration spec MDs (`docs/plans/iteration-N.M-<slug>.md`) **and** populated GitHub issue bodies for that phase. Each iteration's existing level-2 stub is rewritten with real content here. Iterations that `to-issues` decomposes into 2–3 vertical slices spawn additional GitHub issues — the existing stub becomes the **primary** slice, and the additional slices are created as new issues on the same milestone with the same phase + `iteration` labels (each linked back via `Sub-issue of #<primary>` in its body). The iteration's ROADMAP.md row is updated to list all issue numbers in its Issue column.
 - **Scope:** "Exactly what does each iteration in this phase ship, in what order, with what tests?"
 - **Cadence:** one batch per phase, written *before* that phase's first iteration executes
 - **Slash command:** `/plan-phase N` (see `.claude/commands/plan-phase.md`)

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -15,21 +15,19 @@ PRD                                — vision (docs/PRD.md)
     │   • Has NO standalone MD file beyond ROADMAP.md
     │
     └── Iteration                  — the executable atom
-        │   • 1 iteration = 1 AI session = 1 PR = 1 MD file
-        │   • Closes 1–3 GitHub issues per PR
+        │   • 1 iteration = 1 AI session = 1 PR = 1 MD file = 1 GitHub issue
         │   • Spec: docs/plans/iteration-N.M-<slug>.md
         │   • Handoff (output): docs/plans/handoffs/iteration-N.M-handoff.md
         │
-        └── GitHub Issue(s)        — granular deliverables (1–3 per iteration)
+        └── GitHub Issue           — the tracker for this iteration (the PR closes it)
 ```
 
 **Why two levels?** Phase gives semantic context for humans and the roadmap; iteration is the actually-executable unit small enough for one clean context window.
 
 **Sizing rule of thumb:**
-- 1 iteration ≈ 1–2 story points ≈ one focused session ≈ one PR
+- 1 iteration ≈ 1–2 story points ≈ one focused session ≈ one PR ≈ 1 GitHub issue
 - If you want to split: it's multiple iterations under the same phase
-- If 1–3 issues naturally ship together in one PR: that's one iteration
-- 4+ issues per iteration → split it
+- If the work doesn't fit one focused session, split it into multiple iterations
 
 ---
 
@@ -74,8 +72,8 @@ Every `iteration-N.M-<slug>.md` file should have these sections:
 # Iteration N.M — <title>
 
 **Phase:** N — <phase name>
-**GitHub issues:** #A, #B, #C
-**Branch:** `{type}/<primary-issue-#>-<slug>`
+**GitHub issue:** #N
+**Branch:** `{type}/<issue-#>-<slug>`
 **Base branch:** feat/219-ppcp-integration (or release for v3.x hotfixes)
 
 ## Goal

--- a/docs/plans/ROADMAP.md
+++ b/docs/plans/ROADMAP.md
@@ -36,7 +36,7 @@ Source of truth for phases and iterations. GitHub milestone (`v4.0`) and issues 
 
 ## Iterations
 
-> One row per iteration. PR closes 1–3 issues. Iteration MD is the executable spec.
+> One row per iteration. PR closes 1 issue. Iteration MD is the executable spec.
 
 ### Phase 0: Cleanup & Foundation
 

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -6,6 +6,12 @@
       "sourceType": "github",
       "skillPath": "skills/git-commit/SKILL.md",
       "computedHash": "2607fc60629b82b257136dd2a7a373f0a4466c0b49df7746d845d59313c99b21"
+    },
+    "to-issues": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "skillPath": "skills/engineering/to-issues/SKILL.md",
+      "computedHash": "47f648f3414848ccfc62cb41d2828b7e575fb5e7cbd6c4bdf630c063b5dc5e82"
     }
   }
 }


### PR DESCRIPTION
## Iteration

Not part of an iteration — this is a **workflow correction** that adjusts how level-3 (iteration-spec) planning happens for v4.0 and future projects using this repo's scaffolding.

## Summary

- The workflow doc previously prescribed **just-in-time** level-3 planning (write iteration specs in batches of 1–3 immediately before execution). For a project with a stable PRD and a bounded timeline like v4.0, this leaves 37 stub issues with no real content and adds a planning session before nearly every execution session.
- Pivot to **phase-batch** level-3 planning: write all iteration specs for one phase in a single planning session, *before* that phase's first iteration executes. The session also fills in the existing GitHub stub issues for that phase with real content derived from each spec.
- Adds a new `/plan-phase <N>` slash command to orchestrate phase-planning sessions; same thin-orchestration style as the existing `/plan-roadmap` and `/execute-iteration` commands.
- Installs the third-party `to-issues` skill from Matt Pocock ([skills.sh](https://www.skills.sh/mattpocock/skills/to-issues)) as a general-purpose decomposition tool. **Not** wired into `/plan-phase` — round-2 review surfaced a semantic mismatch (the skill publishes fresh issues for every approved slice; our model fills in existing roadmap stubs). The skill stays available for ad-hoc decomposition outside the iteration framework.
- Documents an explicit branch-name exception for planning-only PRs (`docs/plan-phase-<N>`) since they close no iteration issues and can't follow the standard `{type}/{issue-#}-{slug}` convention.

## Scope

- **In scope:**
  - `docs/plans/README.md` — replace just-in-time language with phase-batch model across the File-conventions table, Tactical-planning bullet, Phase-planning section, and Quick-reference table
  - `.claude/commands/plan-phase.md` (new) — the `/plan-phase <N>` slash command with the branch-name exception documented in Step 4
  - `.agents/skills/to-issues/SKILL.md` + `skills-lock.json` — install Matt Pocock's `to-issues` skill per the repo's `.agents/skills/` convention. General-purpose tool; **not used by `/plan-phase`**
  - `AGENTS.md` — Project-skills inventory updated to include `to-issues` with an explicit "not used by /plan-phase" note
- **Out of scope (deferred):**
  - The actual phase-planning work itself — `/plan-phase 0` runs in a follow-up session after this PR merges

## BC / Compat impact

**None.** Documentation, slash-command, and agent-tooling files only. No source code, no `composer.json` changes, no GitHub issue mutations.

The v4.0 milestone (#11), labels, and 43 stub issues from PR #282 stay as-is — their bodies get rewritten by `/plan-phase` sessions one phase at a time as we work through them.

## Test plan

- [x] `docs/plans/README.md` no longer contains the phrase "just-in-time" or "Why just-in-time"
- [x] `.claude/commands/plan-phase.md` exists, follows the same frontmatter + Step structure as `/plan-roadmap` and `/execute-iteration`, and documents the `docs/plan-phase-<N>` branch-name exception
- [x] The new slash command appears in the agent's discoverable skills list as `plan-phase`
- [x] `to-issues` appears in the discoverable skills list and in AGENTS.md's Project-skills inventory with the explicit "not used by /plan-phase" note
- [x] All Copilot review comments from both rounds addressed; all threads resolved
- [ ] (Post-merge sanity check from the next session) `/plan-phase 0` resolves and runs without referencing `to-issues`

## Handoff notes

After this PR merges, the order of operations is:

1. **New session: `/plan-phase 0`** — writes 6 iteration spec MDs (`docs/plans/iteration-0.1-orphan-vendor-cleanup.md` through `docs/plans/iteration-0.6-reference-extraction.md`) and rewrites the bodies of GitHub issues #239–#244 with real content derived from those specs. Branch: `docs/plan-phase-0` per the exception.
2. **Six execution sessions: `/execute-iteration 0.1` through `/execute-iteration 0.6`** — one per iteration, in roadmap order.
3. **New session: `/plan-phase 1`** — and so on through Phase 6.

## Issues

This PR doesn't close any issues. It's a workflow correction, not an iteration.
